### PR TITLE
Fix Url API

### DIFF
--- a/MindbodyOnlineAPI/MindbodyOnlineAPI.php
+++ b/MindbodyOnlineAPI/MindbodyOnlineAPI.php
@@ -16,7 +16,7 @@ use Wmds\MindBodyAPIBundle\MindbodyOnlineAPI\Services\Services;
 
 class MindbodyOnlineAPI {
 
-    const SOAP_URL = "https://api.mindbodyonline.com/0_5";
+    const SOAP_URL = "https://api.mindbodyonline.com/0_5/";
 
     /**
      * @var ContainerInterface


### PR DESCRIPTION
Hi,

When I try with this last commit, API doesn't work.

```
SOAP-ERROR: Parsing WSDL: Couldn't load from 'https://api.mindbodyonline.com/0_5ClassService.asmx?wsdl' : Premature end of data in tag html line 6
```

I've just re-add the last / and it works.

++
