### PR TITLE
Fix an error with HTTPS and SoapClient

### DIFF
--- a/MindbodyOnlineAPI/Services/Services.php
+++ b/MindbodyOnlineAPI/Services/Services.php
@@ -64,7 +64,7 @@ class Services {
     public function __construct($soapURL, $service, $developerCredentials, $userCredentials, $debug, $XMLDetail) {
         $this->debug        = $debug;
         $this->soapClient   = new \SoapClient($soapURL.$this->getServiceWsdl($service), array('trace' => $this->debug));
-
+        $this->soapClient->__setLocation(str_replace("?wsdl","",$soapURL.$this->getServiceWsdl($service)));
         $this->apiData      = array(
             'SourceCredentials' => $developerCredentials,
             'XMLDetail'         => $XMLDetail


### PR DESCRIPTION
SoapClient didn't able to retrieve the WSDL.

See: https://support.mindbodyonline.com/entries/25650748-Switching-API-calls-from-HTTP-to-HTTPS

( it's very new error for us...)
